### PR TITLE
Add trim operation in operation list of sharp engine

### DIFF
--- a/src/engines/sharp.js
+++ b/src/engines/sharp.js
@@ -57,6 +57,7 @@ module.exports = {
     'blur',
     'sharpen',
     'threshold',
+    'trim',
     'interpolateWith',
     'gamma',
     'grayscale',


### PR DESCRIPTION
Impro uses ```gm``` to execute ```trim``` operation. But there is a bug to execute ```trim``` with ```gm```.
For example, after ```gm```  executes ```trim``` the image below, it disappears. but executing ```trim``` with  ```sharp```, it works fine.
The image is used in "more information" section of https://mochajs.org/ and now it doesn't appear.
After applying my change, Impro will use ```sharp``` engine to execute ```trim``` operation and the issue will be fixed.
<div>
<img  width="200" height="200" src="https://user-images.githubusercontent.com/32301380/91654308-9023df80-eae2-11ea-9d62-ec583ad69ed9.png" >
<br>
<em>wallaby-logo</em>
</div>
<div>
<img width="200" height="200" src="https://user-images.githubusercontent.com/32301380/91654353-e2650080-eae2-11ea-813c-288a4b29987b.png">
<br>
<em>wallaby-logo-trimmed</em>
</div>