### PR TITLE
Added support for configuring 'failOnError' for Sharp engine

### DIFF
--- a/src/Impro.js
+++ b/src/Impro.js
@@ -30,6 +30,7 @@ module.exports = class Impro {
       'maxOutputPixels',
       'sharpCache',
       'svgAssetPath',
+      'sharpFailOnError',
     ];
 
     this.restrictedOptions = ['svgAssetPath'];

--- a/src/engines/sharp.js
+++ b/src/engines/sharp.js
@@ -158,6 +158,16 @@ module.exports = {
     options = options ? { ...options } : {};
     const impro = pipeline.impro;
     const cache = pipeline.options.sharpCache || options.cache;
+    const failOnError = (() => {
+      // TODO: Switch to using "Nullish coalescing operator (??)" once only Node.js 14 onwards are supported
+      if (typeof pipeline.options.sharpFailOnError !== 'undefined') {
+        return pipeline.options.sharpFailOnError;
+      } else if (typeof options.failOnError !== 'undefined') {
+        return options.failOnError;
+      } else {
+        return true;
+      }
+    })();
     // Would make sense to move the _sharpCacheSet property to the type, but that breaks some test scenarios:
     if (cache !== 'undefined' && !impro._sharpCacheSet) {
       sharp.cache(cache);
@@ -280,7 +290,7 @@ module.exports = {
     });
 
     // ensure at least one option is present
-    options = { failOnError: true, ...options };
+    options = { failOnError, ...options };
 
     if (pipeline.options.maxInputPixels) {
       options.limitInputPixels = pipeline.options.maxInputPixels;


### PR DESCRIPTION
For allowing/blocking some corrupt images, one may want to configure `failOnError` option of the Sharp library.

eg: Some Samsung devices may generate partially invalid JPEG files. Reference: https://github.com/lovell/sharp/issues/1578

The change in this PR, along with appropriate changes in `express-processimage` library would allow handling of such images.